### PR TITLE
FQL veraltet

### DIFF
--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -12,14 +12,19 @@ class Facebook extends Request implements ServiceInterface
 
     public function getRequest($url)
     {
-        $facebookURL = 'https://api.facebook.com/method/fql.query';
-        $facebookURL .= '?format=json';
-        $facebookURL .= '&query=select like_count from link_stat where url="' . $url . '"';
+        $facebookURL .= 'https://graph.facebook.com/?id=' . $url . '"';
         return $this->createRequest($facebookURL);
     }
 
     public function extractCount($data)
     {
-        return $data[0]['like_count'];
+        if( isset($data['shares']) )
+        {
+            return $data['shares'];
+        }
+        else
+        {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
Da FQL wohl bereits veraltet ist und nicht mehr verwendet werden sollte, würde ich vielleicht eher auf die Graph-API umstellen.

Quelle: https://developers.facebook.com/docs/technical-guides/fql?locale=de_DE