### PR TITLE
New Backend: Xing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shariff PHP Backend [![Build Status](https://travis-ci.org/devimplode/shariff-backend-php.svg?branch=master)](https://travis-ci.org/devimplode/shariff-backend-php)
+# Shariff PHP Backend [![Build Status](https://travis-ci.org/heiseonline/shariff-backend-php.svg?branch=master)](https://travis-ci.org/heiseonline/shariff-backend-php)
 
 Shariff is used to determine how often a page is shared in social media, but without generating requests from the displaying page to the social sites.
 


### PR DESCRIPTION
This one gave me a headache!

##### Includes:
- Xing service
 - via the api used by the Xing-Share-Button (maybe not offical)
- Test for Xing service
 - runs smoothly on Debian/hhvm and Win7/php-5.5
 - fails most of the time if executed on Travis-CI
 - excessively tested against Travis and got this `ResponseException`-Message: [cURL error 35: SSL connect error](https://travis-ci.org/devimplode/shariff-backend-php/jobs/47069183#L207)
 - seems relevant http://serverfault.com/questions/606135/curl-35-ssl-connect-error
 - currently disabled Xing-Test for builds against Travis
 - ToDo: come up with a better solution - maybe longer Timeout
- Readme
 - new Services segment - because it wont fit into the table