### PR TITLE
fix facebook service config and make code more friendly to unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ This zip file contains contains a configuration file `shariff.json`. The followi
 | `ttl` | `integer` | Time that the counts are cached (in seconds) |
 | `cacheDir` | `string` | Directory used for the cache. Default: system temp directory |
 
+##### Service Settings
+
+To pass config options to a service, you can add them to the json as well under the name of the service.
+Currently only the Facebook service has options for an facebook application id and client secret in order to
+use the graph api id method to get the current share count.
+
+| Key         | Type | Description |
+|-------------|------|-------------|
+| `servicename` | `object` | options for the service |
+
+##### Facebook service options
+
+To use the graph api id method to fetch the share count you need to set up an application at facebook.com and pass in the
+application id and client secret to the options. It seems that the id method returns the most current share count, but it
+can be only used with an registered application.
+
+| Key         | Type | Description |
+|-------------|------|-------------|
+| `app_id` | `string` | the id of your facebook application |
+| `secret` | `string` | the client secret of your facebook application |
+
+
 Testing your installation
 -------------------------
 

--- a/src/Backend.php
+++ b/src/Backend.php
@@ -3,26 +3,23 @@
 namespace Heise\Shariff;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Pool;
+use Heise\Shariff\Backend\BackendManager;
+use Heise\Shariff\Backend\ServiceFactory;
 use Zend\Cache\Storage\Adapter\Filesystem;
 
 class Backend
 {
-
-    protected $baseCacheKey;
-    protected $cache;
-    protected $client;
-    protected $domain;
-    protected $services;
+    /** @var BackendManager */
+    protected $backendManager;
 
     public function __construct($config)
     {
-        $this->domain = $config["domain"];
-        $this->client = new Client();
-        $this->baseCacheKey = md5(json_encode($config));
+        $domain = $config["domain"];
+        $client = new Client();
+        $baseCacheKey = md5(json_encode($config));
 
-        $this->cache = new Filesystem();
-        $options = $this->cache->getOptions();
+        $cache = new Filesystem();
+        $options = $cache->getOptions();
         $options->setCacheDir(
             array_key_exists("cacheDir", $config["cache"])
             ? $config["cache"]["cacheDir"]
@@ -33,84 +30,21 @@ class Backend
 
         if (function_exists('register_postsend_function')) {
             // for hhvm installations: executing after response / session close
-            register_postsend_function(function () {
-                $this->cache->clearExpired();
+            register_postsend_function(function () use ($cache) {
+                $cache->clearExpired();
             });
         } else {
             // default
-            $this->cache->clearExpired();
+            $cache->clearExpired();
         }
 
-        $this->services = $this->getServicesByName($config["services"], $config);
+        $serviceFactory = new ServiceFactory($client);
+        $this->backendManager = new BackendManager($baseCacheKey, $cache, $client, $domain, $serviceFactory->getServicesByName($config['services'], $config));
     }
 
-    private function getServicesByName($serviceNames, $config)
-    {
-        $services = array();
-        foreach ($serviceNames as $serviceName) {
-            $serviceName = 'Heise\Shariff\Backend\\'.$serviceName;
-            $newService = new $serviceName();
-            if (isset($config[$serviceName])) {
-                $newService->setConfig($config[$serviceName]);
-            }
-            $services[] = $newService;
-        }
-        return $services;
-    }
-
-    private function isValidDomain($url)
-    {
-        if ($this->domain) {
-            $parsed = parse_url($url);
-            if ($parsed["host"] != $this->domain) {
-                return false;
-            }
-        }
-        return true;
-    }
 
     public function get($url)
     {
-
-        // Aenderungen an der Konfiguration invalidieren den Cache
-        $cache_key = md5($url.$this->baseCacheKey);
-
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
-            return null;
-        }
-
-        if ($this->cache->hasItem($cache_key)) {
-            return json_decode($this->cache->getItem($cache_key), true);
-        }
-
-        if (!$this->isValidDomain($url)) {
-            return null;
-        }
-
-        $requests = array_map(
-            function ($service) use ($url) {
-                return $service->getRequest($url);
-            },
-            $this->services
-        );
-
-        $results = Pool::batch($this->client, $requests);
-
-        $counts = array();
-        $i = 0;
-        foreach ($this->services as $service) {
-            if (method_exists($results[$i], "json")) {
-                try {
-                    $counts[ $service->getName() ] = intval($service->extractCount($results[$i]->json()));
-                } catch (\Exception $e) {
-                    // Skip service if broken
-                }
-            }
-            $i++;
-        }
-
-        $this->cache->setItem($cache_key, json_encode($counts));
-
-        return $counts;
+        return $this->backendManager->get($url);
     }
 }

--- a/src/Backend.php
+++ b/src/Backend.php
@@ -39,7 +39,13 @@ class Backend
         }
 
         $serviceFactory = new ServiceFactory($client);
-        $this->backendManager = new BackendManager($baseCacheKey, $cache, $client, $domain, $serviceFactory->getServicesByName($config['services'], $config));
+        $this->backendManager = new BackendManager(
+            $baseCacheKey,
+            $cache,
+            $client,
+            $domain,
+            $serviceFactory->getServicesByName($config['services'], $config)
+        );
     }
 
 

--- a/src/Backend/BackendManager.php
+++ b/src/Backend/BackendManager.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * www.valiton.com
+ *
+ * @author Uwe Jäger <uwe.jaeger@valiton.com>
+ */
+
+
+namespace Heise\Shariff\Backend;
+
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Pool;
+use Zend\Cache\Storage\StorageInterface;
+
+class BackendManager
+{
+    /** @var string */
+    protected $baseCacheKey;
+
+    /** @var StorageInterface */
+    protected $cache;
+
+    /** @var Client */
+    protected $client;
+
+    /** @var string */
+    protected $domain;
+
+    /** @var ServiceInterface[] */
+    protected $services;
+
+    public function __construct($baseCacheKey, $cache, $client, $domain, $services)
+    {
+        $this->baseCacheKey = $baseCacheKey;
+        $this->cache = $cache;
+        $this->client = $client;
+        $this->domain = $domain;
+        $this->services = $services;
+    }
+
+    private function isValidDomain($url)
+    {
+        if ($this->domain) {
+            $parsed = parse_url($url);
+            if ($parsed["host"] != $this->domain) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function get($url)
+    {
+
+        // Aenderungen an der Konfiguration invalidieren den Cache
+        $cache_key = md5($url.$this->baseCacheKey);
+
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return null;
+        }
+
+        if ($this->cache->hasItem($cache_key)) {
+            return json_decode($this->cache->getItem($cache_key), true);
+        }
+
+        if (!$this->isValidDomain($url)) {
+            return null;
+        }
+
+        $requests = array_map(
+            function ($service) use ($url) {
+                return $service->getRequest($url);
+            },
+            $this->services
+        );
+
+        $results = Pool::batch($this->client, $requests);
+
+        $counts = array();
+        $i = 0;
+        foreach ($this->services as $service) {
+            if (method_exists($results[$i], "json")) {
+                try {
+                    $counts[ $service->getName() ] = intval($service->extractCount($results[$i]->json()));
+                } catch (\Exception $e) {
+                    // Skip service if broken
+                }
+            }
+            $i++;
+        }
+
+        $this->cache->setItem($cache_key, json_encode($counts));
+
+        return $counts;
+    }
+
+}

--- a/src/Backend/BackendManager.php
+++ b/src/Backend/BackendManager.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * www.valiton.com
- *
- * @author Uwe Jäger <uwe.jaeger@valiton.com>
- */
-
 
 namespace Heise\Shariff\Backend;
-
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
@@ -94,5 +87,4 @@ class BackendManager
 
         return $counts;
     }
-
 }

--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -4,7 +4,6 @@ namespace Heise\Shariff\Backend;
 
 class Facebook extends Request implements ServiceInterface
 {
-    protected $config;
 
     public function getName()
     {
@@ -32,11 +31,6 @@ class Facebook extends Request implements ServiceInterface
         }
 
         return null;
-    }
-
-    public function setConfig(array $config)
-    {
-        $this->config = $config;
     }
 
     protected function getAccesToken()

--- a/src/Backend/Request.php
+++ b/src/Backend/Request.php
@@ -6,12 +6,15 @@ use GuzzleHttp\Client;
 
 abstract class Request
 {
-
+    /** @var Client */
     protected $client;
 
-    public function __construct()
+    /** @var array */
+    protected $config;
+
+    public function __construct(Client $client)
     {
-        $this->client = new Client();
+        $this->client = $client;
     }
 
     protected function createRequest($url, $method = 'GET', $options = array())
@@ -30,6 +33,6 @@ abstract class Request
 
     public function setConfig(array $config)
     {
-        // convenience implementation empty
+        $this->config = $config;
     }
 }

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * www.valiton.com
+ *
+ * @author Uwe Jäger <uwe.jaeger@valiton.com>
+ */
+
+
+namespace Heise\Shariff\Backend;
+
+
+use GuzzleHttp\Client;
+
+class ServiceFactory
+{
+    /** @var Client */
+    protected $client;
+
+    /** @var array */
+    protected $serviceMap;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+        $this->serviceMap = array();
+    }
+
+    public function registerService($name, $service)
+    {
+        $this->serviceMap[$name] = $service;
+    }
+
+    public function getServicesByName($serviceNames, $config)
+    {
+        $services = array();
+        foreach ($serviceNames as $serviceName) {
+            $services[] = $this->createService($serviceName, $config);
+        }
+        return $services;
+    }
+
+    protected function createService($serviceName, $config)
+    {
+        if (isset($this->serviceMap[$serviceName])) {
+            $service = $this->serviceMap[$serviceName];
+        } else {
+            $serviceClass = 'Heise\Shariff\Backend\\'.$serviceName;
+            $service = new $serviceClass($this->client);
+        }
+
+        if (isset($config[$serviceName])) {
+            $service->setConfig($config[$serviceName]);
+        }
+
+        return $service;
+    }
+
+}

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * www.valiton.com
- *
- * @author Uwe Jäger <uwe.jaeger@valiton.com>
- */
-
 
 namespace Heise\Shariff\Backend;
-
 
 use GuzzleHttp\Client;
 
@@ -54,5 +47,4 @@ class ServiceFactory
 
         return $service;
     }
-
 }

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * www.valiton.com
- *
- * @author Uwe Jäger <uwe.jaeger@valiton.com>
- */
-
 
 namespace Heise\Tests\Shariff;
-
 
 use GuzzleHttp\Message\Request;
 use GuzzleHttp\Message\Response;
@@ -43,7 +36,8 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
             ->method('createRequest')
             ->with(
                 'GET',
-                'https://graph.facebook.com/oauth/access_token?client_id=foo&client_secret=bar&grant_type=client_credentials'
+                'https://graph.facebook.com/oauth/access_token'
+                    . '?client_id=foo&client_secret=bar&grant_type=client_credentials'
             )
         ;
 
@@ -79,7 +73,10 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $facebook = new Facebook($client);
         $facebook->setConfig(array('app_id' => 'foo', 'secret' => 'bar'));
         $url = $facebook->getRequest('http://www.heise.de')->getUrl();
-        $this->assertEquals('https://graph.facebook.com/v2.2/?id='.urlencode('http://www.heise.de'). '&access_token=token', $url);
+        $this->assertEquals(
+            'https://graph.facebook.com/v2.2/?id='.urlencode('http://www.heise.de'). '&access_token=token',
+            $url
+        );
     }
 
     public function createRequest($method, $url, $options)

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -37,7 +37,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
             ->with(
                 'GET',
                 'https://graph.facebook.com/oauth/access_token'
-                    . '?client_id=foo&client_secret=bar&grant_type=client_credentials'
+                  . '?client_id=foo&client_secret=bar&grant_type=client_credentials'
             )
         ;
 

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * www.valiton.com
+ *
+ * @author Uwe Jäger <uwe.jaeger@valiton.com>
+ */
+
+
+namespace Heise\Tests\Shariff;
+
+
+use GuzzleHttp\Message\Request;
+use GuzzleHttp\Message\Response;
+use Heise\Shariff\Backend\Facebook;
+
+class FacebookTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConfig()
+    {
+        $client = $this->getMockBuilder('GuzzleHttp\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $response = $this->getMockBuilder('GuzzleHttp\Message\ResponseInterface')
+            ->getMock();
+
+        $response
+            ->method('getBody')
+            ->willReturn('access_token=tokem')
+        ;
+
+        $client
+            ->method('send')
+            ->willReturn($response)
+        ;
+
+        $client
+          ->method('createRequest')
+          ->will($this->returnCallback(array($this, 'createRequest')))
+        ;
+
+        $client->expects($this->at(0))
+            ->method('createRequest')
+            ->with(
+                'GET',
+                'https://graph.facebook.com/oauth/access_token?client_id=foo&client_secret=bar&grant_type=client_credentials'
+            )
+        ;
+
+        $facebook = new Facebook($client);
+        $facebook->setConfig(array('app_id' => 'foo', 'secret' => 'bar'));
+        $facebook->getRequest('http://www.heise.de');
+    }
+
+    public function testUsesGraphApi()
+    {
+        $client = $this->getMockBuilder('GuzzleHttp\Client')
+          ->disableOriginalConstructor()
+          ->getMock();
+
+        $response = $this->getMockBuilder('GuzzleHttp\Message\ResponseInterface')
+          ->getMock();
+
+        $response
+          ->method('getBody')
+          ->willReturn('access_token=token')
+        ;
+
+        $client
+          ->method('send')
+          ->willReturn($response)
+        ;
+
+        $client
+          ->method('createRequest')
+          ->will($this->returnCallback(array($this, 'createRequest')))
+        ;
+
+        $facebook = new Facebook($client);
+        $facebook->setConfig(array('app_id' => 'foo', 'secret' => 'bar'));
+        $url = $facebook->getRequest('http://www.heise.de')->getUrl();
+        $this->assertEquals('https://graph.facebook.com/v2.2/?id='.urlencode('http://www.heise.de'). '&access_token=token', $url);
+    }
+
+    public function createRequest($method, $url, $options)
+    {
+        return new Request($method, $url, $options);
+    }
+}

--- a/tests/ServiceFactoryTest.php
+++ b/tests/ServiceFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * www.valiton.com
+ *
+ * @author Uwe Jäger <uwe.jaeger@valiton.com>
+ */
+
+
+namespace Heise\Tests\Shariff;
+
+
+use GuzzleHttp\Client;
+use Heise\Shariff\Backend\ServiceFactory;
+
+class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testSetConfig()
+    {
+        $mockService = $this->getMockBuilder('Heise\Shariff\Backend\ServiceInterface')
+            ->getMock();
+
+        $mockService->expects($this->once())
+            ->method('setConfig')
+            ->with(array('foo' => 'bar'))
+        ;
+
+        $serviceFactory = new ServiceFactory(new Client());
+        $serviceFactory->registerService('MockService', $mockService);
+
+        $services = $serviceFactory->getServicesByName(array('MockService'), array('MockService' => array('foo' => 'bar')));
+        $this->assertCount(1, $services);
+    }
+
+    public function testConfigNotSet()
+    {
+        $mockService = $this->getMockBuilder('Heise\Shariff\Backend\ServiceInterface')
+          ->getMock();
+
+        $mockService->expects($this->never())
+          ->method('setConfig')
+        ;
+
+        $serviceFactory = new ServiceFactory(new Client());
+        $serviceFactory->registerService('MockService', $mockService);
+
+        $services = $serviceFactory->getServicesByName(array('MockService'), array('OtherService' => array('foo' => 'bar')));
+        $this->assertCount(1, $services);
+    }
+
+}

--- a/tests/ServiceFactoryTest.php
+++ b/tests/ServiceFactoryTest.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * www.valiton.com
- *
- * @author Uwe Jäger <uwe.jaeger@valiton.com>
- */
-
 
 namespace Heise\Tests\Shariff;
-
 
 use GuzzleHttp\Client;
 use Heise\Shariff\Backend\ServiceFactory;
@@ -28,7 +21,10 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceFactory = new ServiceFactory(new Client());
         $serviceFactory->registerService('MockService', $mockService);
 
-        $services = $serviceFactory->getServicesByName(array('MockService'), array('MockService' => array('foo' => 'bar')));
+        $services = $serviceFactory->getServicesByName(
+            array('MockService'),
+            array('MockService' => array('foo' => 'bar'))
+        );
         $this->assertCount(1, $services);
     }
 
@@ -44,8 +40,10 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceFactory = new ServiceFactory(new Client());
         $serviceFactory->registerService('MockService', $mockService);
 
-        $services = $serviceFactory->getServicesByName(array('MockService'), array('OtherService' => array('foo' => 'bar')));
+        $services = $serviceFactory->getServicesByName(
+            array('MockService'),
+            array('OtherService' => array('foo' => 'bar'))
+        );
         $this->assertCount(1, $services);
     }
-
 }


### PR DESCRIPTION
This fixes and documents the service configuration to use the graph api for facebook. To be able to add some unit tests I also refactored the code (basically passing most of the dependency from outside to the classes that do the lifting while keeping the Backend class to do the configuration). 

The new ServiceFactory now also allows to add services from anywhere if you do not use the Backend class ...

We now use only one guzzle client which makes it possible to configure that as well (e.g. add some timeout values etc.)

Any comments welcome.