### PR TITLE
make it possible to pass options to guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ This zip file contains contains a configuration file `shariff.json`. The followi
 | `ttl` | `integer` | Time that the counts are cached (in seconds) |
 | `cacheDir` | `string` | Directory used for the cache. Default: system temp directory |
 
+##### Client options
+
+The backend uses [Guzzle](http://docs.guzzlephp.org/en/latest/) as HTTP client. Guzzle has many options that you can set, e.g. timeout and connect_timeout. See http://docs.guzzlephp.org/en/latest/clients.html#request-options for a detailed list.
+In order to set those options pass them in the json with the key "client".
+
+| Key         | Type | Description |
+|-------------|------|-------------|
+| `client` | `object` | Guzzle request options |
+
 ##### Service Settings
 
 To pass config options to a service, you can add them to the json as well under the name of the service. Currently only the Facebook service has options for an facebook application id and client secret in order to use the graph api id method to get the current share count.

--- a/src/Backend.php
+++ b/src/Backend.php
@@ -15,7 +15,11 @@ class Backend
     public function __construct($config)
     {
         $domain = $config["domain"];
-        $client = new Client();
+        $clientOptions = [];
+        if (isset($config['client'])) {
+            $clientOptions = $config['client'];
+        }
+        $client = new Client(['defaults' => $clientOptions]);
         $baseCacheKey = md5(json_encode($config));
 
         $cache = new Filesystem();

--- a/tests/ShariffTest.php
+++ b/tests/ShariffTest.php
@@ -79,4 +79,22 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($counts);
     }
+
+    public function testClientOptions()
+    {
+        $shariff = new Backend(array(
+            "domain"   => 'www.heise.de',
+            "cache"    => array("ttl" => 1),
+            "services" => $this->services,
+            "client" => array(
+                "timeout" => 0.005,
+                "connect_timeout" => 0.005
+            )
+        ));
+
+        $counts = $shariff->get('http://www.heise.de');
+
+        // expect no response in 5 ms
+        $this->assertCount(0, $counts);
+    }
 }


### PR DESCRIPTION
This addresses #15 and also allows you to set a timeout to make this more responsive if a service does not respond in a timely manner