### PR TITLE
allow to use different caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,14 @@ This zip file contains contains a configuration file `shariff.json`. The followi
 
 ##### Cache settings:
 
+By default Shariff uses the Filesystem cache. By specifying a different adapter from Zend\Cache\Storage\Adapter you can tell Shariff to use another cache. Also you can specify options for that cache adapter
+
 | Key         | Type | Description |
 |-------------|------|-------------|
 | `ttl` | `integer` | Time that the counts are cached (in seconds) |
 | `cacheDir` | `string` | Directory used for the cache. Default: system temp directory |
+| `adapter` | `string` | Name of cache adapter (e.g. Apc, Memcache, etc.) |
+| `adapterOptions` | `object` | Options for the cache adapter |
 
 ##### Service Settings
 

--- a/tests/ShariffTest.php
+++ b/tests/ShariffTest.php
@@ -79,4 +79,31 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($counts);
     }
+
+    public function testApcCache()
+    {
+        $this->setExpectedException('Zend\Cache\Exception\ExtensionNotLoadedException');
+        $shariff = new Backend(array(
+            "domain"   => 'www.heise.de',
+            "cache"    => array("adapter" => "Apc", "ttl" => 0),
+            "services" => $this->services
+        ));
+        $this->fail('APC should not be enabled for test');
+    }
+
+    public function testCacheOptions()
+    {
+        $shariff = new Backend(array(
+            "domain"   => 'www.heise.de',
+            "cache"    => array(
+                "adapter" => "Dba",
+                "adapterOptions" => array("pathname" => tempnam(sys_get_temp_dir(), 'shariff')),
+                "ttl" => 0
+            ),
+            "services" => $this->services
+        ));
+
+        $counts = $shariff->get('http://www.heise.de');
+        $this->assertGreaterThan(0, count($counts));
+    }
 }

--- a/tests/ShariffTest.php
+++ b/tests/ShariffTest.php
@@ -93,17 +93,17 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
 
     public function testCacheOptions()
     {
+        $this->setExpectedException('Zend\Cache\Exception\OutOfSpaceException');
         $shariff = new Backend(array(
             "domain"   => 'www.heise.de',
             "cache"    => array(
-                "adapter" => "Dba",
-                "adapterOptions" => array("pathname" => tempnam(sys_get_temp_dir(), 'shariff')),
+                "adapter" => "Memory",
+                "adapterOptions" => array("memoryLimit" => 10),
                 "ttl" => 0
             ),
             "services" => $this->services
         ));
-
         $counts = $shariff->get('http://www.heise.de');
-        $this->assertGreaterThan(0, count($counts));
+        $this->fail('10 bytes should not be enough for the cache');
     }
 }

--- a/tests/ShariffTest.php
+++ b/tests/ShariffTest.php
@@ -82,6 +82,10 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
 
     public function testApcCache()
     {
+        if ('hhvm' == getenv('TRAVIS_PHP_VERSION')) {
+            $this->markTestSkipped('APC seems to work for hhvm');
+        }
+
         $this->setExpectedException('Zend\Cache\Exception\ExtensionNotLoadedException');
         $shariff = new Backend(array(
             "domain"   => 'www.heise.de',


### PR DESCRIPTION
It would be nice to be able to use the other caches from Zend\Cache.