### PR TITLE
[BUGFIX] Avoid guzzle 6.0 update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
     	"php": ">=5.4.0",
-        "guzzlehttp/guzzle": "*",
+        "guzzlehttp/guzzle": "~5.2",
         "zendframework/zend-cache": "*",
         "zendframework/zend-config": "*",
         "zendframework/zend-json": "*"


### PR DESCRIPTION
Limit the version for guzzle in order to avoid an update to version 6+
by composer. Guzzle 6+ has lots of breaking changes and does not work
with shariff-backend-php anymore.