### PR TITLE
Updated min PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-    	"php": ">=5.4.0",
+    	"php": ">=5.5.0",
         "guzzlehttp/guzzle": "~5.2",
         "zendframework/zend-cache": "2.5.1",
         "zendframework/zend-config": "2.5.1",


### PR DESCRIPTION
We should drop the support of php 5.4 as it has reached its EOL. https://secure.php.net/eol.php