### PR TITLE
proper url encoding

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ class Application
         $reader = new Json();
 
         $shariff = new Backend($reader->fromFile('shariff.json'));
-        echo json_encode($shariff->get($_GET["url"]));
+        echo json_encode($shariff->get(urlencode($_GET["url"])));
     }
 }
 

--- a/src/Backend/BackendManager.php
+++ b/src/Backend/BackendManager.php
@@ -69,7 +69,7 @@ class BackendManager
         // Aenderungen an der Konfiguration invalidieren den Cache
         $cache_key = md5($url.$this->baseCacheKey);
 
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+        if (!filter_var(urldecode($url), FILTER_VALIDATE_URL)) {
             return null;
         }
 
@@ -77,7 +77,7 @@ class BackendManager
             return json_decode($this->cache->getItem($cache_key), true);
         }
 
-        if (!$this->isValidDomain($url)) {
+        if (!$this->isValidDomain(urldecode($url))) {
             return null;
         }
 


### PR DESCRIPTION
Added urlencode() to the url to allow hash fragments in urls like http://example.com/#target
Makes facebook counts working if url has hashes.