### PR TITLE
[BUGFIX] Avoid PHP notices for missing array keys

### DIFF
--- a/src/Backend/AddThis.php
+++ b/src/Backend/AddThis.php
@@ -34,6 +34,6 @@ class AddThis extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        return $data['shares'];
+        return isset($data['shares']) ? $data['shares'] : 0;
     }
 }

--- a/src/Backend/GooglePlus.php
+++ b/src/Backend/GooglePlus.php
@@ -48,6 +48,9 @@ class GooglePlus extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        return $data['result']['metadata']['globalCounts']['count'];
+        if (!empty($data['result']['metadata']['globalCounts']['count'])) {
+            return $data['result']['metadata']['globalCounts']['count'];
+        }
+        return 0;
     }
 }

--- a/src/Backend/LinkedIn.php
+++ b/src/Backend/LinkedIn.php
@@ -34,6 +34,6 @@ class LinkedIn extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        return $data['count'];
+        return isset($data['count']) ? $data['count'] : 0;
     }
 }

--- a/src/Backend/Pinterest.php
+++ b/src/Backend/Pinterest.php
@@ -44,6 +44,6 @@ class Pinterest extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        return $data['count'];
+        return isset($data['count']) ? $data['count'] : 0;
     }
 }

--- a/src/Backend/Reddit.php
+++ b/src/Backend/Reddit.php
@@ -34,8 +34,12 @@ class Reddit extends Request implements ServiceInterface
     public function extractCount(array $data)
     {
         $count = 0;
-        foreach ($data['data']['children'] as $child) {
-            $count += $child['data']['score'];
+        if (!empty($data['data']['children'])) {
+            foreach ($data['data']['children'] as $child) {
+                if (!empty($child['data']['score'])) {
+                    $count += $child['data']['score'];
+                }
+            }
         }
         return $count;
     }

--- a/src/Backend/Xing.php
+++ b/src/Backend/Xing.php
@@ -40,6 +40,6 @@ class Xing extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        return $data['share_counter'];
+        return isset($data['share_counter']) ? $data['share_counter'] : 0;
     }
 }


### PR DESCRIPTION
Update the services to check for array key existence.