### PR TITLE
[BUGFIX] Remove wrong composer bin-reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     ],
     "keywords": ["heise", "social buttons", "shariff"],
     "description": "PHP backend for Shariff. Shariff enables website users to share their favorite content without compromising their privacy.",
-    "bin": ["index.php"],
     "homepage": "https://github.com/heiseonline/shariff-backend-php",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
index.php is not intended as binary usage.
Do not advertise this in composer.json