### PR TITLE
Clarify documentation regarding `domains` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This zip file contains a configuration file `shariff.json`. The following config
 |-------------|------|-------------|
 | `cacheClass` | `string` | *Optional* Cache class name. Has to implement `Heise\Shariff\CacheInterface`. Defaults to internal Zend Cache. |
 | `cache` | `object`  | File cache settings, which are passed on to the Cache class. See description below. |
-| `domains` | `array` | Domains for which share counts may be requested |
+| `domains` | `array` | Domains for which share counts may be requested. If empty, all domains are allowed. |
 | `services` | `array` | List of services to be enabled. See [Supported services](#supported-services). |
 
 ##### Cache settings:


### PR DESCRIPTION
Obviously, the current behavior is to [treat any domain as valid](https://github.com/heiseonline/shariff-backend-php/blob/master/src/Backend/BackendManager.php#L69), if `domains` is an empty array. Either this should be better documented (what this PR is about), or BackendManager::isValidDomain() should be changed (might be preferable for security reasons, but might break existing configurations on update).