### PR TITLE
Travis: Check lowest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,17 @@ php:
  - 5.6
  - 7.0
 
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-lowest"
+
 before_script:
  - bash -c 'if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;'
  - composer self-update
- - composer install --prefer-dist --no-interaction
  - composer require "squizlabs/php_codesniffer=*"
+ - travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
  - bash -c 'vendor/bin/phpcs --standard=PSR2 src/ tests/'


### PR DESCRIPTION
Travis should check the lowest dependencies required in the `composer.json` file.