### PR TITLE
[BUGFIX] Prevent fatal in case the result is not an array

### DIFF
--- a/src/Backend/BackendManager.php
+++ b/src/Backend/BackendManager.php
@@ -112,7 +112,8 @@ class BackendManager
             } else {
                 try {
                     $content = $service->filterResponse($results[$i]->getBody()->getContents());
-                    $counts[$service->getName()] = (int) $service->extractCount(json_decode($content, true));
+                    $json = json_decode($content, true);
+                    $counts[$service->getName()] = is_array($json) ? (int) $service->extractCount($json) : 0;
                 } catch (\Exception $e) {
                     if ($this->logger !== null) {
                         $this->logger->warning($e->getMessage(), ['exception' => $e]);


### PR DESCRIPTION
This patch prevents a fatal error in case the result from a service
cannot be parsed and is e.g. null instead of an array.
The extractCount method expects an array as parameter.