### PR TITLE
Use facebook api v2.10

### DIFF
--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -43,9 +43,11 @@ class Facebook extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        if (isset($data['engagement']['reaction_count'],
-                $data['engagement']['comment_count'],
-                $data['engagement']['share_count'])) {
+        if (isset(
+            $data['engagement']['reaction_count'],
+            $data['engagement']['comment_count'],
+            $data['engagement']['share_count']
+            )) {
             return $data['engagement']['reaction_count']
                 + $data['engagement']['comment_count']
                 + $data['engagement']['share_count'];

--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -43,9 +43,9 @@ class Facebook extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        if (isset($data['engagement']['reaction_count'])
-            && isset($data['engagement']['comment_count'])
-            && isset($data['engagement']['share_count'])) {
+        if (isset($data['engagement']['reaction_count'],
+                $data['engagement']['comment_count'],
+                $data['engagement']['share_count'])) {
             return $data['engagement']['reaction_count']
                 + $data['engagement']['comment_count']
                 + $data['engagement']['share_count'];

--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -32,7 +32,8 @@ class Facebook extends Request implements ServiceInterface
     public function getRequest($url)
     {
         $accessToken = urlencode($this->config['app_id']) .'|'.urlencode($this->config['secret']);
-        $query = 'https://graph.facebook.com/v2.10/?id='.urlencode($url).'&fields=engagement&access_token='.$accessToken;
+        $query = 'https://graph.facebook.com/v2.10/?id='.urlencode($url) . '&fields=engagement&access_token='
+            . $accessToken;
 
         return new \GuzzleHttp\Psr7\Request('GET', $query);
     }
@@ -42,8 +43,10 @@ class Facebook extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        if (isset($data['engagement']) && isset($data['engagement']['reaction_count']) && isset($data['engagement']['comment_count']) && isset($data['engagement']['share_count'])) {
-            return $data['engagement']['reaction_count'] + $data['engagement']['comment_count'] + $data['engagement']['share_count'];
+        if (isset($data['engagement']) && isset($data['engagement']['reaction_count'])
+            && isset($data['engagement']['comment_count']) && isset($data['engagement']['share_count'])) {
+            return $data['engagement']['reaction_count'] + $data['engagement']['comment_count']
+                + $data['engagement']['share_count'];
         }
 
         return 0;

--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -43,9 +43,11 @@ class Facebook extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        if (isset($data['engagement']) && isset($data['engagement']['reaction_count'])
-            && isset($data['engagement']['comment_count']) && isset($data['engagement']['share_count'])) {
-            return $data['engagement']['reaction_count'] + $data['engagement']['comment_count']
+        if (isset($data['engagement']['reaction_count'])
+            && isset($data['engagement']['comment_count'])
+            && isset($data['engagement']['share_count'])) {
+            return $data['engagement']['reaction_count']
+                + $data['engagement']['comment_count']
                 + $data['engagement']['share_count'];
         }
 

--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -32,7 +32,7 @@ class Facebook extends Request implements ServiceInterface
     public function getRequest($url)
     {
         $accessToken = urlencode($this->config['app_id']) .'|'.urlencode($this->config['secret']);
-        $query = 'https://graph.facebook.com/v2.8/?id='.urlencode($url).'&access_token='.$accessToken;
+        $query = 'https://graph.facebook.com/v2.10/?id='.urlencode($url).'&fields=engagement&access_token='.$accessToken;
 
         return new \GuzzleHttp\Psr7\Request('GET', $query);
     }
@@ -42,11 +42,8 @@ class Facebook extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        if (isset($data['data']) && isset($data['data'][0]) && isset($data['data'][0]['total_count'])) {
-            return $data['data'][0]['total_count'];
-        }
-        if (isset($data['share']) && isset($data['share']['share_count'])) {
-            return $data['share']['share_count'];
+        if (isset($data['engagement']) && isset($data['engagement']['reaction_count']) && isset($data['engagement']['comment_count']) && isset($data['engagement']['share_count'])) {
+            return $data['engagement']['reaction_count'] + $data['engagement']['comment_count'] + $data['engagement']['share_count'];
         }
 
         return 0;

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -31,9 +31,9 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $request = $facebook->getRequest('http://www.heise.de');
 
         $this->assertEquals('graph.facebook.com', $request->getUri()->getHost());
-        $this->assertEquals('/v2.8/', $request->getUri()->getPath());
+        $this->assertEquals('/v2.10/', $request->getUri()->getPath());
         $this->assertEquals(
-            'id='.urlencode('http://www.heise.de').'&access_token=foo%7Cbar',
+            'id='.urlencode('http://www.heise.de').'&fields=engagement&access_token=foo%7Cbar',
             $request->getUri()->getQuery()
         );
     }


### PR DESCRIPTION
Use current facebook api version v2.10 and adapt to changes in v2.9.

This also solves issue [https://github.com/heiseonline/shariff-backend-php/issues/127](https://github.com/heiseonline/shariff-backend-php/issues/127).

Beginning with v2.9, the api requires the fields parameter to be set if it shall return not only the
id but additional fields, and the fields have been reorganised and renamed.

See [https://developers.facebook.com/docs/graph-api/changelog/version2.9#gapi-changes-general](https://developers.facebook.com/docs/graph-api/changelog/version2.9#gapi-changes-general):

- GET /{url}/share - The share endpoint has been removed and replaced with:
  - engagement field with subfields:
    - comment_count
    - comment_plugin_count
    - reaction_count
    - share_count

The Facebook Like button shows then the total of all these counts, except of the comment_plugin_count, which seems to belong to the deprecated comment plugin, so I did not include this one into the total.

See following examples from a test (the token parameter in the URL has to be replaced by a valid token you can get at the Facebook Api Explorer).

- https://graph.facebook.com/v2.8/?id=https%3A%2F%2Fwww.heise.de&access_token=xyz has returned following Json data:

> {
>    "share": {
>       "comment_count": 0,
>       "share_count": 674
>    },
>    "og_object": {
>       "id": "331776430263909",
>       "description": "News und Foren zu Computer, IT, Wissenschaft, Medien und Politik. Preisvergleich von Hardware und Software sowie Downloads bei Heise Medien.",
>       "title": "heise online",
>       "type": "website",
>       "updated_time": "2017-11-01T17:13:02+0000"
>    },
>    "id": "https://www.heise.de"
> }

- https://graph.facebook.com/v2.10/?id=https%3A%2F%2Fwww.heise.de&fields=engagement,og_object&access_token=xyz  has returned following Json data:

> {
>    "engagement": {
>       "reaction_count": 153,
>       "comment_count": 107,
>       "share_count": 414,
>       "comment_plugin_count": 0
>    },
>    "og_object": {
>       "id": "331776430263909",
>       "description": "News und Foren zu Computer, IT, Wissenschaft, Medien und Politik. Preisvergleich von Hardware und Software sowie Downloads bei Heise Medien.",
>       "title": "heise online",
>       "type": "website",
>       "updated_time": "2017-11-01T17:13:02+0000"
>    },
>    "id": "https://www.heise.de"
> }

How to test:

Verify that for an URL for which shariff-backend-php works well, the shariff-backend-php without this pull request applied and the and shariff-backend-php with this pull request applied show the same count for facebook if queried at the same time.

Why to change to latest api version:

When creating an app_id on the Facebook app dashboard, it is bound to the current API version, i.e. you can't select an api version lower than that. So if you today create an app, you can select only v2.10 as api version in the dashboard, and querying that app on Facebook Graph Object Explorer using api version v2.8 and a key made from the app_id and the secret of the app and not of a current user, you will not get a result.

Additional info:

When using a dedicated Facebook API version, e.g. "https://graph.facebook.com/v2.10/", and not only "https://graph.facebook.com/" without version, then the result is always in the format for that version, i.e. the check in the source code for array elements belonging to older API versions is not necessary. Therefore it is sufficient to check only for the result of that API version  and not the older things "if (isset($data['data']) && isset($data['data'][0]) && isset($data['data'][0]['total_count']))" for very old versions which meanwhile are not available anymore and "if (isset($data['share']) && isset($data['share']['share_count']))" for version v2.8 in addition, like it is now in the source code, which checks both old alternatives. Maybe this was some remainder from old code when no version folder "/vX.Y" (like now "/v2.8") was used in the query URL, so the result could be returned in different formats depending on the version used by the APP belonging to the app_id parameter.