### PR TITLE
Update Facebook service to latest Graph API version v2.11

### DIFF
--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -32,7 +32,7 @@ class Facebook extends Request implements ServiceInterface
     public function getRequest($url)
     {
         $accessToken = urlencode($this->config['app_id']) .'|'.urlencode($this->config['secret']);
-        $query = 'https://graph.facebook.com/v2.10/?id='.urlencode($url) . '&fields=engagement&access_token='
+        $query = 'https://graph.facebook.com/v2.11/?id='.urlencode($url) . '&fields=engagement&access_token='
             . $accessToken;
 
         return new \GuzzleHttp\Psr7\Request('GET', $query);

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -31,7 +31,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $request = $facebook->getRequest('http://www.heise.de');
 
         $this->assertEquals('graph.facebook.com', $request->getUri()->getHost());
-        $this->assertEquals('/v2.10/', $request->getUri()->getPath());
+        $this->assertEquals('/v2.11/', $request->getUri()->getPath());
         $this->assertEquals(
             'id='.urlencode('http://www.heise.de').'&fields=engagement&access_token=foo%7Cbar',
             $request->getUri()->getQuery()


### PR DESCRIPTION
Use current facebook api version v2.11

How to test: Code review should be sufficient, but if necessary, check if Facebook counts still work with this PR applied.

Reason for this PR:

As already elaborated in PR [#128](https://github.com/heiseonline/shariff-backend-php/pull/128), Shariff backend will not get any result for an app_id if the app has been created with a newer Graph API version than the one which Shariff backend uses in the URL for getting the counts, because a Facebook app is limited to the minimum Graph API version which was current when tha AP has been created.

So the Shariff backend either has to always use the current Graph AQPI version when getting the counts, which means do what this PR does not with every new API version, and if necessary also adapt to changes in the API like PR [#128](https://github.com/heiseonline/shariff-backend-php/pull/128) did.

Or the other way would be to use versionless URL for getting the counts, and then having to adapt to changes with respect to deprecation of old API versions only, and possibly having a more tolerant method to extract the counts for the diverse possible result formats.

For details about all this, versioning of the API and using versionless queries to the API, see [https://developers.facebook.com/docs/apps/versions/](https://developers.facebook.com/docs/apps/versions/).

Please maintainers check this link and discuss which is your preferred method to follow the Graph API versions: With versioned calls so Shariff backend will frequently update to the latest version, or with versionless calls. If you prefer versionless calls, I can make another PR to implement that.

