### PR TITLE
Add service "Vk"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Supported services
 - Reddit
 - StumbleUpon
 - Xing
+- Vk
 
 Requirements
 ------------
@@ -123,7 +124,8 @@ private static $configuration = [
         'Flattr',
         'Pinterest',
         'Xing',
-        'AddThis'
+        'AddThis',
+        'Vk'
     ],
     'Facebook' => [
       'app_id' => '1234567890',
@@ -139,7 +141,7 @@ Testing your installation
 If the backend runs under `http://example.com/my-shariff-backend/`, calling the URL `http://example.com/my-shariff-backend/?url=http%3A%2F%2Fwww.example.com` should return a JSON structure with numbers in it, e.g.:
 
 ```json
-{"facebook":1452,"googleplus":23,"linkedin":118,"reddit":7,"stumbleupon":4325,"flattr":0,"pinterest":3,"addthis":33}
+{"facebook":1452,"googleplus":23,"linkedin":118,"reddit":7,"stumbleupon":4325,"flattr":0,"pinterest":3,"addthis":33,"vk":326}
 ```
 
 
@@ -154,7 +156,7 @@ use Heise\Shariff\Backend;
 $options = [
 	"domains"  => ["www.heise.de", "www.ct.de"],
 	"cache"    => ["ttl" => 1],
-	"services" => ["Facebook", "GooglePlus", "LinkedIn", "Reddit", "StumbleUpon", "Flattr", "Pinterest", "AddThis"]
+	"services" => ["Facebook", "GooglePlus", "LinkedIn", "Reddit", "StumbleUpon", "Flattr", "Pinterest", "AddThis", "Vk"]
 ];
 $shariff = new Backend($options);
 $counts = $shariff->get("http://www.heise.de/");

--- a/index.php
+++ b/index.php
@@ -31,7 +31,8 @@ class Application
             'Flattr',
             'Pinterest',
             'Xing',
-            'AddThis'
+            'AddThis',
+            'Vk'
         ]
     ];
 

--- a/src/Backend/Vk.php
+++ b/src/Backend/Vk.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Heise\Shariff\Backend;
+
+/**
+ * Class Vk.
+ */
+class Vk extends Request implements ServiceInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'vk';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequest($url)
+    {
+        return new \GuzzleHttp\Psr7\Request(
+            'GET',
+            'https://vk.com/share.php?act=count&index=1&url='.urlencode($url)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterResponse($content)
+    {
+        // 'VK.Share.count(1, x);' with x being the count
+        $strCount = mb_substr($content, 18, mb_strlen($content) - 20);
+        return ($strCount ? '{"count": ' . $strCount . '}': '');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extractCount(array $data)
+    {
+        return isset($data['count']) ? $data['count'] : 0;
+    }
+}

--- a/tests/ShariffTest.php
+++ b/tests/ShariffTest.php
@@ -20,7 +20,8 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
         "Pinterest",
         "Reddit",
         // "StumbleUpon",
-        "Xing"
+        "Xing",
+        "Vk"
     );
 
     public function testShariff()
@@ -73,6 +74,12 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
         if (array_key_exists('reddit', $counts)) {
             $this->assertInternalType('int', $counts['reddit']);
             $this->assertGreaterThanOrEqual(0, $counts['reddit']);
+        }
+
+        // $this->assertArrayHasKey('vk', $counts);
+        if (array_key_exists('vk', $counts)) {
+            $this->assertInternalType('int', $counts['vk']);
+            $this->assertGreaterThanOrEqual(0, $counts['vk']);
         }
     }
 


### PR DESCRIPTION
Since the service "Vk" has been added to Shariff with release 2.1.0 (meanwhile 2.1.1 is current), this service should also be added to the backends.

A working demo can be found here: [https://www.richard-fath.de/shariff-plus-demo/index.html](https://www.richard-fath.de/shariff-plus-demo/index.html). In opposite to the standard Shariff demo page, it uses a real php backend extended by this pull request and not just a dummy backend made with a json file. You can see VK in examples 2 and 3 of that demo.

Thanks to [https://github.com/abhn/Social-Share-Counts](https://github.com/abhn/Social-Share-Counts) for the info about how to get the share count.
  
  