### PR TITLE
Handle missing or deleted services

### DIFF
--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -15,6 +15,9 @@ class ServiceFactory
     /** @var ServiceInterface[] */
     protected $serviceMap = [];
 
+    /** @var DeletedServices[] */
+    protected $deletedServices = ['GooglePlus', 'Twitter'];
+
     /**
      * @param ClientInterface $client
      */
@@ -42,6 +45,9 @@ class ServiceFactory
     {
         $services = [];
         foreach ($serviceNames as $serviceName) {
+            if (in_array($serviceName, $deletedServices)) {
+                continue;
+            }
             try {
                 $service = $this->createService($serviceName, $config);
             } catch (\InvalidArgumentException $e) {

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -45,10 +45,8 @@ class ServiceFactory
     {
         $services = [];
         foreach ($serviceNames as $serviceName) {
-            if (in_array($serviceName, $this->deletedServices)) {
-                continue;
-            }
-            if (!file_exists(__DIR__ . '/' . $serviceName . '.php')) {
+            if (in_array($serviceName, $this->deletedServices)
+                || !file_exists(__DIR__ . '/' . $serviceName . '.php')) {
                 continue;
             }
             try {

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -45,14 +45,13 @@ class ServiceFactory
     {
         $services = [];
         foreach ($serviceNames as $serviceName) {
-            if (in_array($serviceName, $this->deletedServices)
-                || !file_exists(__DIR__ . '/' . $serviceName . '.php')) {
-                continue;
-            }
-            try {
-                $service = $this->createService($serviceName, $config);
-            } catch (\InvalidArgumentException $e) {
-                continue;
+            if (!in_array($serviceName, $this->deletedServices)
+                && file_exists(__DIR__ . '/' . $serviceName . '.php')) {
+                try {
+                    $service = $this->createService($serviceName, $config);
+                } catch (\InvalidArgumentException $e) {
+                    continue;
+                }
             }
             $services[] = $service;
         }

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -45,13 +45,14 @@ class ServiceFactory
     {
         $services = [];
         foreach ($serviceNames as $serviceName) {
-            if (!in_array($serviceName, $this->deletedServices)
-                && file_exists(__DIR__ . '/' . $serviceName . '.php')) {
-                try {
-                    $service = $this->createService($serviceName, $config);
-                } catch (\InvalidArgumentException $e) {
-                    continue;
-                }
+            if (in_array($serviceName, $this->deletedServices)
+                || !file_exists(__DIR__ . '/' . $serviceName . '.php')) {
+                continue;
+            }
+            try {
+                $service = $this->createService($serviceName, $config);
+            } catch (\InvalidArgumentException $e) {
+                continue;
             }
             $services[] = $service;
         }

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -45,15 +45,18 @@ class ServiceFactory
     {
         $services = [];
         foreach ($serviceNames as $serviceName) {
+            $service = NULL;
             if (!in_array($serviceName, $this->deletedServices)
                 && file_exists(__DIR__ . '/' . $serviceName . '.php')) {
                 try {
                     $service = $this->createService($serviceName, $config);
                 } catch (\InvalidArgumentException $e) {
-                    continue;
+                    // Do nothing.
                 }
             }
-            $services[] = $service;
+            if (!is_null($service)) {
+                $services[] = $service;
+            }
         }
 
         return $services;

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -45,7 +45,7 @@ class ServiceFactory
     {
         $services = [];
         foreach ($serviceNames as $serviceName) {
-            if (in_array($serviceName, $deletedServices)) {
+            if (in_array($serviceName, $this->deletedServices)) {
                 continue;
             }
             if (!file_exists(__DIR__ . '/' . $serviceName . '.php')) {

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -45,18 +45,15 @@ class ServiceFactory
     {
         $services = [];
         foreach ($serviceNames as $serviceName) {
-            $service = NULL;
             if (!in_array($serviceName, $this->deletedServices)
                 && file_exists(__DIR__ . '/' . $serviceName . '.php')) {
                 try {
                     $service = $this->createService($serviceName, $config);
                 } catch (\InvalidArgumentException $e) {
-                    // Do nothing.
+                    continue;
                 }
             }
-            if (!is_null($service)) {
-                $services[] = $service;
-            }
+            $services[] = $service;
         }
 
         return $services;

--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -48,6 +48,9 @@ class ServiceFactory
             if (in_array($serviceName, $deletedServices)) {
                 continue;
             }
+            if (!file_exists(__DIR__ . '/' . $serviceName . '.php')) {
+                continue;
+            }
             try {
                 $service = $this->createService($serviceName, $config);
             } catch (\InvalidArgumentException $e) {


### PR DESCRIPTION
As discussed with pull request (PR) #132 , the backend crashes with fatal PHP error in case if the php source for a service is missing, e.g. if the service has been removed from the backend like Twitter and GooglePlus, and so the PHP files have been removed, but the services are still configured to be used in index.php.

This PR here adds handling for this case in 2 ways:

1. Have a list of removed services' names and don't use that service if the service name is in that list.
2. Don' use a service if the php source file for that service doesn't exist.

**How to test:**

1. By code review. If you think that variable $deletedServices in file ServiceFactory.php should better be a const, just let me know, and I'll change that.
2. Check that all implemented services still work.
3. Have some deleted service like "Twitter" or "GooglePlus" configured in your index.php and have the php file for that service in your backend from older backend versions, and check that for these services no counters are returned, but all other implemented services work.
4. Have some nonsense service like "Gaga" or "Blabla" configured in your index.php for which no php file exists, and check that all implemented services work.

I have tested this on a Linux & Apache environment. It would be good if someone could test that on a Windows & IIS environment, too, just to make sure that the file_exists works there like it should.