### PR TITLE
[BUGFIX] Add a proper check if a requested service exists

### DIFF
--- a/src/Backend/ServiceFactory.php
+++ b/src/Backend/ServiceFactory.php
@@ -64,7 +64,10 @@ class ServiceFactory
         if (isset($this->serviceMap[$serviceName])) {
             $service = $this->serviceMap[$serviceName];
         } else {
-            $serviceClass = 'Heise\\Shariff\\Backend\\'.$serviceName;
+            $serviceClass = '\\Heise\\Shariff\\Backend\\'.$serviceName;
+            if (!class_exists($serviceClass)) {
+                throw new \InvalidArgumentException('Invalid service name "' . $serviceName . '".');
+            }
             $service = new $serviceClass($this->client);
         }
 


### PR DESCRIPTION
Before a service class is instantiated a check is added to avoid abortion of the script run.
This shall gracefully handle invalid configuration, which may list invalid (or abandoned) service names.