### PR TITLE
Send requests to pinterest via https

### DIFF
--- a/src/Backend/Pinterest.php
+++ b/src/Backend/Pinterest.php
@@ -22,7 +22,7 @@ class Pinterest extends Request implements ServiceInterface
     {
         return new \GuzzleHttp\Psr7\Request(
             'GET',
-            'http://api.pinterest.com/v1/urls/count.json?callback=x&url='.urlencode($url)
+            'https://api.pinterest.com/v1/urls/count.json?callback=x&url='.urlencode($url)
         );
     }
 


### PR DESCRIPTION
Last time we have a lot of failed requests to pinterest with response `426 Unknown` which asks us to upgrade protocol (requests like ` http://api.pinterest.com/v1/urls/count.json?callback=x&url=...`). Requests via browser always redirected us to https. Would you be so kind to review, merge this and create new release?

Thank you