### PR TITLE
Add service "Buffer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This document describes the PHP backend of Shariff.
 Supported services
 ------------------
 - AddThis
+- Buffer
 - Facebook
 - Flattr
 - LinkedIn
@@ -119,6 +120,7 @@ private static $configuration = [
         'Pinterest',
         'Xing',
         'AddThis',
+        'Buffer',
         'Vk'
     ],
     'Facebook' => [
@@ -135,7 +137,7 @@ Testing your installation
 If the backend runs under `http://example.com/my-shariff-backend/`, calling the URL `http://example.com/my-shariff-backend/?url=http%3A%2F%2Fwww.example.com` should return a JSON structure with numbers in it, e.g.:
 
 ```json
-{"facebook":1452,"linkedin":118,"reddit":7,"stumbleupon":4325,"flattr":0,"pinterest":3,"addthis":33,"vk":326}
+{"facebook":1452,"linkedin":118,"reddit":7,"stumbleupon":4325,"flattr":0,"pinterest":3,"addthis":33,"buffer":29,"vk":326}
 ```
 
 
@@ -150,7 +152,7 @@ use Heise\Shariff\Backend;
 $options = [
 	"domains"  => ["www.heise.de", "www.ct.de"],
 	"cache"    => ["ttl" => 1],
-	"services" => ["Facebook", "LinkedIn", "Reddit", "StumbleUpon", "Flattr", "Pinterest", "AddThis", "Vk"]
+	"services" => ["Facebook", "LinkedIn", "Reddit", "StumbleUpon", "Flattr", "Pinterest", "AddThis", "Buffer", "Vk"]
 ];
 $shariff = new Backend($options);
 $counts = $shariff->get("http://www.heise.de/");

--- a/index.php
+++ b/index.php
@@ -31,6 +31,7 @@ class Application
             'Pinterest',
             'Xing',
             'AddThis',
+            'Buffer',
             'Vk'
         ]
     ];

--- a/src/Backend/Buffer.php
+++ b/src/Backend/Buffer.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Heise\Shariff\Backend;
+
+/**
+ * Class Buffer.
+ */
+class Buffer extends Request implements ServiceInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'buffer';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequest($url)
+    {
+        return new \GuzzleHttp\Psr7\Request(
+            'GET',
+            'https://api.bufferapp.com/1/links/shares.json?url='.urlencode($url)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extractCount(array $data)
+    {
+        return isset($data['shares']) ? $data['shares'] : 0;
+    }
+}

--- a/tests/ShariffTest.php
+++ b/tests/ShariffTest.php
@@ -20,6 +20,7 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
         "Reddit",
         // "StumbleUpon",
         "Xing",
+        "Buffer"
         "Vk"
     );
 
@@ -67,6 +68,12 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
         if (array_key_exists('reddit', $counts)) {
             $this->assertInternalType('int', $counts['reddit']);
             $this->assertGreaterThanOrEqual(0, $counts['reddit']);
+        }
+
+        // $this->assertArrayHasKey('buffer', $counts);
+        if (array_key_exists('buffer', $counts)) {
+            $this->assertInternalType('int', $counts['buffer']);
+            $this->assertGreaterThanOrEqual(0, $counts['buffer']);
         }
 
         // $this->assertArrayHasKey('vk', $counts);

--- a/tests/ShariffTest.php
+++ b/tests/ShariffTest.php
@@ -20,7 +20,7 @@ class ShariffTest extends \PHPUnit_Framework_TestCase
         "Reddit",
         // "StumbleUpon",
         "Xing",
-        "Buffer"
+        "Buffer",
         "Vk"
     );
 


### PR DESCRIPTION
This pull request (P) adds the new service "Buffer" for [buffer](https://buffer.com/).

Buffer is something very similar to AddThis and provides an API to get the share counts, see section "Buffer Share Count" here: [https://www.madebymagnitude.com/blog/getting-your-social-share-counts-with-php/](https://www.madebymagnitude.com/blog/getting-your-social-share-counts-with-php/).

I have tested this PR in a local testing environment. The result share counts for URL="https://www.heise.de/" using services `'AddThis', 'Buffer', 'Facebook', 'Flattr', 'LinkedIn', 'Pinterest', 'StumbleUpon', 'Xing', 'Vk'` was:

`{"addthis":310,"buffer":188,"facebook":2454,"flattr":0,"linkedin":0,"pinterest":17,"stumbleupon":0,"xing":227}`