### PR TITLE
Fix cacheClass in full example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ use Heise\Shariff\LaminasCache;
  * @var array
  */
 private static $configuration = [
-    'cacheClass' => LaminasCache::class,
+    'cacheClass' => 'Heise\\Shariff\\LaminasCache',
     'cache' => [
         'ttl' => 60,
         'cacheDir' => '/tmp/shariff/cache',


### PR DESCRIPTION
When using
```php
use Heise\Shariff\LaminasCache;
/**
 * Sample configuration
 *
 * @var array
 */
private static $configuration = [
    'cacheClass' => LaminasCache::class,
...
```
like currently written in the full example in README.md, I get a PHP error about class not being found.

When using
```php
use Heise\Shariff\LaminasCache;
/**
 * Sample configuration
 *
 * @var array
 */
private static $configuration = [
    'cacheClass' => 'Heise\\Shariff\\LaminasCache',
...
```
it works.

This PR corrects the full example in README.md to reflect this.

When not specifying the cache class in index.php, everything works, too, so nothing else to be changed, Backend.php is correct.