### PR TITLE
Set user-agent in example readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ private static $configuration = [
         ]
     ],
     'client' => [
-      'timeout' => 4.2
+      'timeout' => 4.2,
+      'headers' => [
+        'User-Agent' => 'shariff/1.0',
+      ]
       // ... (see "Client options")
     ],
     'domains' => [


### PR DESCRIPTION
In my experience (as described in https://github.com/heiseonline/shariff-backend-php/issues/171), the Reddit API does block this backend really fast if no user agent header is set. To avoid this issue it would be good for the example configuration file to set an user agent. 