### PR TITLE
Raise guzzlehttp/guzzle version for 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.1",
+        "guzzlehttp/guzzle": "^7.0",
         "psr/log": "^1.0",
         "laminas/laminas-cache": "^2.7"
     },


### PR DESCRIPTION
This PR updates the version of `guzzlehttp/guzzle` to be compatible with 7x.

Related issue: #175 