### PR TITLE
Update Facebook service to latest Facebook Graph API version v12.0 and change field from engagement to og_object

### DIFF
--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -31,8 +31,8 @@ class Facebook extends Request implements ServiceInterface
      */
     public function getRequest($url)
     {
-        $accessToken = urlencode($this->config['app_id']) .'|'.urlencode($this->config['secret']);
-        $query = 'https://graph.facebook.com/v7.0/?id='.urlencode($url) . '&fields=engagement&access_token='
+        $accessToken = urlencode($this->config['app_id']) . '|' . urlencode($this->config['secret']);
+        $query = 'https://graph.facebook.com/v12.0/?id=' . urlencode($url) . '&fields=og_object%7Bengagement%7D&access_token='
             . $accessToken;
 
         return new \GuzzleHttp\Psr7\Request('GET', $query);
@@ -43,14 +43,8 @@ class Facebook extends Request implements ServiceInterface
      */
     public function extractCount(array $data)
     {
-        if (isset(
-            $data['engagement']['reaction_count'],
-            $data['engagement']['comment_count'],
-            $data['engagement']['share_count']
-        )) {
-            return $data['engagement']['reaction_count']
-                + $data['engagement']['comment_count']
-                + $data['engagement']['share_count'];
+        if (isset($data['og_object']['engagement']['count'])) {
+            return $data['og_object']['engagement']['count'];
         }
 
         return 0;

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -35,7 +35,7 @@ class FacebookTest extends PHPUnit\TestCase
         $request = $facebook->getRequest('http://www.heise.de');
 
         $this->assertEquals('graph.facebook.com', $request->getUri()->getHost());
-        $this->assertEquals('/v11.0/', $request->getUri()->getPath());
+        $this->assertEquals('/v12.0/', $request->getUri()->getPath());
         $this->assertEquals(
             'id='.urlencode('http://www.heise.de').'&fields=og_object%7Bengagement%7D&access_token=foo%7Cbar',
             $request->getUri()->getQuery()

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -20,7 +20,7 @@ class FacebookTest extends PHPUnit\TestCase
         $facebook->setConfig(array('app_id' => 'foo', 'secret' => 'bar'));
         $request = $facebook->getRequest('http://www.heise.de');
         $this->assertEquals(
-            'id='.urlencode('http://www.heise.de').'&fields=engagement&access_token=foo%7Cbar',
+            'id='.urlencode('http://www.heise.de').'&fields=og_object%7Bengagement%7D&access_token=foo%7Cbar',
             $request->getUri()->getQuery()
         );
     }

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -35,9 +35,9 @@ class FacebookTest extends PHPUnit\TestCase
         $request = $facebook->getRequest('http://www.heise.de');
 
         $this->assertEquals('graph.facebook.com', $request->getUri()->getHost());
-        $this->assertEquals('/v7.0/', $request->getUri()->getPath());
+        $this->assertEquals('/v11.0/', $request->getUri()->getPath());
         $this->assertEquals(
-            'id='.urlencode('http://www.heise.de').'&fields=engagement&access_token=foo%7Cbar',
+            'id='.urlencode('http://www.heise.de').'&fields=og_object%7Bengagement%7D&access_token=foo%7Cbar',
             $request->getUri()->getQuery()
         );
     }


### PR DESCRIPTION
Current Facebook Graph API version v12.0 has been released yesterday, Tuesday, September 14, 2021, see [https://developers.facebook.com/docs/graph-api/changelog](https://developers.facebook.com/docs/graph-api/changelog).

According to the changelog, there have not been any breaking changes regarding sharing counts, see [https://developers.facebook.com/docs/graph-api/changelog/version12.0](https://developers.facebook.com/docs/graph-api/changelog/version12.0), so theoretically only the version number would have to be increased with this PR here.

But there is something which has been noted in the release notes of version v10.0 which has an impact on getting the share counters, see section "URL" [https://developers.facebook.com/docs/graph-api/changelog/version10.0](https://developers.facebook.com/docs/graph-api/changelog/version10.0) :

```
URL

Applies to v10.0+. Will apply to all versions on May 25, 2021.

Engagement
- Due to privacy concerns, counts returned by a "GET /?id={url}/engagement" request may not match raw counts. 
- Requests for the "GET /?id={url}/engagement" field for the same URL will be limited to 10 requests per hour.
```

The first point seems to be the reason that the counters in the answer are all zero when using the existing code with just the version number changed, like I have done it many times with PR, the last one is #169 .

But if I change `fields=engagement` to `fields=og_object{engagement}` (or to be precise, `fields=og_object%7Bengagement%7D` with the curly brasckets encoded), then it works, and the response looks like:

```
{
   "og_object": {
      "engagement": {
         "count": 43,
         "social_sentence": "43 people like this."
      },
      "id": "132647790271874"
   },
   "id": "http://www.richard-fath.de/de/music/recordings/htlv-iii.html"
}
```

The count is the total of the 3 counts which are received with the current code without this PR.

This PR here makes the necessary changes to work that way. I also works with previous API versions in that way.

The second point mentioned in their change log could make it necessary to re-consider something like suggested in issue #148 .

But it could also be that the restriction doesn't apply with the change in this PR. The docs are not clear to me about this.

How to test: Code review should be sufficient, but if necessary, check if Facebook counts still work with this PR applied and if the result is the same as without this PR applied. Of course I've tested this on my website, as usual.

Reason for this PR:

As already elaborated in PR [#128](https://github.com/heiseonline/shariff-backend-php/pull/128), Shariff backend will not get any result for an app_id if the app has been created with a newer Graph API version than the one which Shariff backend uses in the URL for getting the counts, because a Facebook app is limited to the minimum Graph API version which was current when the app has been created.

In addition, it could be necessary soon to get this PR merged due to the statement `Applies to v10.0+. Will apply to all versions on May 25, 2021.` in their change log.