### PR TITLE
Remove obsolete "Flattr" service remainders from unit test

### DIFF
--- a/tests/ShariffTest.php
+++ b/tests/ShariffTest.php
@@ -16,7 +16,6 @@ class ShariffTest extends PHPUnit\TestCase
      */
     protected $services = [
         // "Facebook",
-        // "Flattr",
         "Pinterest",
         "Reddit",
         // "StumbleUpon",
@@ -34,12 +33,6 @@ class ShariffTest extends PHPUnit\TestCase
         ]);
 
         $counts = $shariff->get('https://www.heise.de');
-
-        // $this->assertArrayHasKey('flattr', $counts);
-        if (array_key_exists('flattr', $counts)) {
-            $this->assertIsInt($counts['flattr']);
-            $this->assertGreaterThanOrEqual(0, $counts['flattr']);
-        }
 
         // $this->assertArrayHasKey('pinterest', $counts);
         if (array_key_exists('pinterest', $counts)) {


### PR DESCRIPTION
This pull request (PR) removes all remainders of the obsolete "Flattr" service from unit tests.

The  "Flattr" service has been removed with my PR #190 in 2023, but I had overlooked the remainders which are removed with my PR here.