### PR TITLE
Update Facebook service to latest Facebook Graph API version v26.0

### DIFF
--- a/src/Backend/Facebook.php
+++ b/src/Backend/Facebook.php
@@ -35,7 +35,7 @@ class Facebook extends Request implements ServiceInterface
     public function getRequest(string $url): RequestInterface
     {
         $accessToken = urlencode($this->config['app_id']) . '|' . urlencode($this->config['secret']);
-        $query = 'https://graph.facebook.com/v25.0/?id='
+        $query = 'https://graph.facebook.com/v26.0/?id='
             . urlencode($url) . '&fields=og_object%7Bengagement%7D&access_token=' . $accessToken;
 
         return new \GuzzleHttp\Psr7\Request('GET', $query);

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -36,7 +36,7 @@ class FacebookTest extends PHPUnit\TestCase
         $request = $facebook->getRequest('https://www.heise.de');
 
         $this->assertEquals('graph.facebook.com', $request->getUri()->getHost());
-        $this->assertEquals('/v25.0/', $request->getUri()->getPath());
+        $this->assertEquals('/v26.0/', $request->getUri()->getPath());
         $this->assertEquals(
             'id=' . urlencode('https://www.heise.de') . '&fields=og_object%7Bengagement%7D&access_token=foo%7Cbar',
             $request->getUri()->getQuery()


### PR DESCRIPTION
Current Facebook Graph API version is v26.0, see [https://developers.facebook.com/docs/graph-api/changelog](https://developers.facebook.com/docs/graph-api/changelog).

There have not been any breaking changes regarding sharing counts, see [https://developers.facebook.com/docs/graph-api/changelog/version26.0](https://developers.facebook.com/docs/graph-api/changelog/version26.0), so only the version number has to be increased with this PR here.

How to test: Code review should be sufficient, but if necessary, check if Facebook counts still work with this PR applied. Of course I've tested this on my website, as usual.

Reason for this PR:

As already elaborated in PR [#128](https://github.com/heiseonline/shariff-backend-php/pull/128), Shariff backend will not get any result for an app_id if the app has been created with a newer Graph API version than the one which Shariff backend uses in the URL for getting the counts, because a Facebook app is limited to the minimum Graph API version which was current when the app has been created.